### PR TITLE
Setting global font was disabled

### DIFF
--- a/tpl_lessallrounder/templateDetails.xml
+++ b/tpl_lessallrounder/templateDetails.xml
@@ -63,7 +63,6 @@
 				<field name="sansFontFamily" type="font"
 					label="TPL_ALLROUNDER_FONT_FAMILY" description="TPL_ALLROUNDER_FONT_FAMILY_DESC"
 					default="Verdana, Helvetica, Sans-Serif"
-					disabled="true"
 					onchange="toggleElement('sansFontFamily', 1);"
 				>
 					<option value="Verdana, Helvetica, Sans-Serif">Verdana, Helvetica, Sans-Serif</option>


### PR DESCRIPTION
Is there any special reason to keep the Global font-family dropdown   disabled? I don't see it :)
