### PR TITLE
Opened Accordions uses suitable image part

### DIFF
--- a/tpl_lessallrounder/css/template.css
+++ b/tpl_lessallrounder/css/template.css
@@ -7164,6 +7164,7 @@ p.img_caption {
 	padding: 0 0 0 35px;
 	background-color: #eee;
 	background-image: url(../images/accordion.jpg);
+	background-position: left -60px;
 	background-repeat: no-repeat;
 	border: 1px solid #aaa;
 	border-bottom-color: #bbb;
@@ -7174,8 +7175,13 @@ p.img_caption {
 .accordion-heading .accordion-toggle:hover {
 	color: #000;
 	background-color: #fff;
-	background-position: left -30px;
 	text-decoration: none;
+}
+.accordion-heading .accordion-toggle.collapsed {
+	background-position: left  0px;
+}
+.accordion-heading .accordion-toggle.collapsed:hover {
+	background-position: left  -30px;
 }
 hr {
 	border: none;

--- a/tpl_lessallrounder/css/template.css
+++ b/tpl_lessallrounder/css/template.css
@@ -7161,17 +7161,8 @@ p.img_caption {
 .accordion-group {
 	margin-top: 10px;
 }
-.accordion-group.panel.active .accordion-heading .accordion-toggle,
-.accordion-group .accordion-heading .accordion-toggle:not(.collapsed):not(.rl_sliders-toggle) {
-	color: #0099FF;
-	background-position: left -60px;
-}
-.accordion-group.panel.active .accordion-heading .accordion-toggle:hover,
-.accordion-group .accordion-heading .accordion-toggle:not(.collapsed):not(.rl_sliders-toggle):hover {
-	color: #000;
-}
 .accordion-heading .accordion-toggle {
-	color: #555;
+	color: #0099FF;
 	font-weight: bold;
 	height: 30px;
 	line-height: 30px;
@@ -7192,6 +7183,7 @@ p.img_caption {
 	text-decoration: none;
 }
 .accordion-heading .accordion-toggle.collapsed {
+	color: #555;
 	background-position: left  0px;
 }
 .accordion-heading .accordion-toggle.collapsed:hover {

--- a/tpl_lessallrounder/js/effects.js
+++ b/tpl_lessallrounder/js/effects.js
@@ -79,4 +79,7 @@ jQuery(document).ready(function($) {
 			$("label[for=" + $(this).attr('id') + "]").addClass('active btn-success');
 		}
 	});
+
+	// add collapsed to collapsed accordions heading (Joomla adds this class on first collapse)
+	$('.accordion-body.collapse:not(.in)').parent().find('.accordion-toggle').addClass('collapsed');
 });

--- a/tpl_lessallrounder/js/effects.js
+++ b/tpl_lessallrounder/js/effects.js
@@ -79,7 +79,4 @@ jQuery(document).ready(function($) {
 			$("label[for=" + $(this).attr('id') + "]").addClass('active btn-success');
 		}
 	});
-
-	// add collapsed to collapsed accordions heading (Joomla adds this class on first collapse)
-	$('.accordion-body.collapse:not(.in)').parent().find('.accordion-toggle').addClass('collapsed');
 });

--- a/tpl_lessallrounder/less/typo.less
+++ b/tpl_lessallrounder/less/typo.less
@@ -1,18 +1,9 @@
 /* Pimp Bootstrap Accordion */
 .accordion-group {
 	margin-top: 10px;
-	/* Special support for Sliders from NoNumber */
-	&.panel.active .accordion-heading .accordion-toggle,
-	.accordion-heading .accordion-toggle:not(.collapsed):not(.rl_sliders-toggle) {
-		color: #0099FF;
-		background-position: left -60px;
-		&:hover {
-			color: #000;
-		}
-	}
 }
 .accordion-heading .accordion-toggle {
-	color: #555;
+	color: #0099FF;
 	font-weight: bold;
 	height: 30px;
 	line-height: 30px;
@@ -29,7 +20,8 @@
 		background-color: #fff;
 		text-decoration: none;
 	}
-	&.collapsed {		
+	&.collapsed {
+		color: #555;
 		background-position: left 0px;
 		&:hover {
 			background-position: left -30px;

--- a/tpl_lessallrounder/less/typo.less
+++ b/tpl_lessallrounder/less/typo.less
@@ -18,6 +18,7 @@
 	padding: 0 0 0 35px;
 	background-color: #eee;
 	background-image: url(../images/accordion.jpg);
+	background-position: left 60px;
 	background-repeat: no-repeat;
 	border: 1px solid #aaa;
 	border-bottom-color:#bbb;
@@ -25,8 +26,13 @@
 	&:hover {
 		color: #000;
 		background-color: #fff;
-		background-position: left -30px;
 		text-decoration: none;
+	}
+	&.collapsed {		
+		background-position: left 0px;
+		&:hover {
+			background-position: left -30px;
+		}
 	}
 }
 /* Horizontal Rules */


### PR DESCRIPTION
Now the opened accordions are using the image part with the "x" instead
those with the "+".