### PR TITLE
improve radio field and btn-group

### DIFF
--- a/tpl_lessallrounder/css/template.css
+++ b/tpl_lessallrounder/css/template.css
@@ -7110,7 +7110,7 @@ legend {
 fieldset.filters {
 	margin-bottom: 10px;
 }
-.edit #adminForm fieldset {
+.edit #adminForm > fieldset {
 	border: solid 1px #ddd;
 	padding: 20px 15px;
 	margin-top: 10px;

--- a/tpl_lessallrounder/js/effects.js
+++ b/tpl_lessallrounder/js/effects.js
@@ -67,6 +67,7 @@ jQuery(document).ready(function($) {
 				label.addClass('active btn-success');
 			}
 			input.prop('checked', true);
+			input.trigger('change');
 		}
 	});
 	$(".btn-group input[checked=checked]").each(function()

--- a/tpl_lessallrounder/less/joomla.less
+++ b/tpl_lessallrounder/less/joomla.less
@@ -206,7 +206,7 @@ fieldset.filters {
 	margin-bottom: 10px;
 }
 /* adminForm */
-.edit #adminForm fieldset {
+.edit #adminForm > fieldset {
 	border: solid 1px #ddd;
 	padding: 20px 15px;
 	margin-top: 10px;


### PR DESCRIPTION
Now `showon` pointing to `btn-group` works. For details see https://github.com/joomla/joomla-cms/pull/11923 which fixes this issue for Protostar.  
Joomla renders the `radio` field as `fieldset`. This was displayed with border and a lot of space around it, which was ugly. All frontend components have `fieldset` as direct child of `#adminForm`.