### PR TITLE
remove unneeded space from btn-group/radio/checkboxes

### DIFF
--- a/tpl_lessallrounder/css/template.css
+++ b/tpl_lessallrounder/css/template.css
@@ -2584,6 +2584,20 @@ input[type="submit"].btn.btn-mini {
 	min-width: 84px;
 	padding: 2px 12px;
 }
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 0px;
+}
+.form-horizontal .controls > .radio:first-child,
+.form-horizontal .controls > .checkbox:first-child {
+	padding-top: 5px;
+}
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
+}
+.form-horizontal .controls > .radio.btn-group-yesno:first-child {
+	padding-top: 2px;
+}
 .btn-group {
 	position: relative;
 	display: inline-block;

--- a/tpl_lessallrounder/less/buttons.less
+++ b/tpl_lessallrounder/less/buttons.less
@@ -220,3 +220,23 @@ input[type="submit"].btn {
   min-width: 84px;
   padding: 2px 12px;
 }
+
+/* Remove unneeded space between label and field in vertical forms */
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 0px;
+
+	.form-horizontal & {
+		padding-top: 5px;
+	}
+}
+
+/* Align btn-group to label */
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
+}
+
+/* Align btn-group-yesno to label */
+.form-horizontal .controls > .radio.btn-group-yesno:first-child {
+	padding-top: 2px;
+}


### PR DESCRIPTION
In vertical from there was unneeded space between the label and the
controls under it.
Removed padding-top of btn-group to align with label.
Added 2px padding-top to btn-group-yes to compensate 2px less
padding-top of each button to have the buttons aligned with the label.

This PR adapts the changes from https://github.com/joomla/joomla-cms/pull/12003.