### PR TITLE
fix search in subhead floats to new line in desktop view

### DIFF
--- a/tpl_lessallrounder/css/template.css
+++ b/tpl_lessallrounder/css/template.css
@@ -7789,6 +7789,9 @@ span.dropcap {
 		margin: 8px 0 0 26px;
 		max-width: 650px;
 	}
+	#subhead .breadcrumb {
+		float: left;
+	}
 }
 @media (max-width: 767px) {
 	.breadcrumb {

--- a/tpl_lessallrounder/less/breadcrumbs.less
+++ b/tpl_lessallrounder/less/breadcrumbs.less
@@ -1,6 +1,9 @@
 .breadcrumb_less_desktop () {
 	margin: 8px 0 0 26px;
 	max-width: 650px;
+	#subhead & {
+		float: left;
+	}
 }
 .breadcrumb_less() when (@navbarCollapseWidth > 0) {
 	@media (min-width: @navbarCollapseDesktopWidth) {


### PR DESCRIPTION
add `float: left` for breadcrumb in `#subhead`