### PR TITLE
Adjust message classes

### DIFF
--- a/tpl_lessallrounder/html/layouts/joomla/system/message.php
+++ b/tpl_lessallrounder/html/layouts/joomla/system/message.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Template.protostar
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$msgList = $displayData['msgList'];
+
+$alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-info', 'message' => 'alert-success');
+?>
+<div id="system-message-container">
+	<?php if (is_array($msgList) && !empty($msgList)) : ?>
+		<div id="system-message">
+			<?php foreach ($msgList as $type => $msgs) : ?>
+				<div class="alert <?php echo isset($alert[$type]) ? $alert[$type] : 'alert-' . $type; ?>">
+					<?php // This requires JS so we should add it through JS. Progressive enhancement and stuff. ?>
+					<a class="close" data-dismiss="alert">×</a>
+
+					<?php if (!empty($msgs)) : ?>
+						<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
+						<div>
+							<?php foreach ($msgs as $msg) : ?>
+								<div class="alert-message"><?php echo $msg; ?></div>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
Joomla uses different message classes than Bootstrap.
At the moment messages from type `message` and `notice` are displayed like `warning`.

This PR imports the messages layout from Protostar.