### PR TITLE
customCssCode: change type from textarea to editor

### DIFF
--- a/tpl_lessallrounder/templateDetails.xml
+++ b/tpl_lessallrounder/templateDetails.xml
@@ -496,12 +496,16 @@
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 				</field>
-				<field name="customCssCode" type="textarea"
+				<field name="customCssCode" type="editor"
 					label="TPL_ALLROUNDER_OWN_CSS"
 					description="TPL_ALLROUNDER_OWN_CSS_DESC"
 					hint="/* enter your CSS code here */"
+					editor="codemirror|none"
+					buttons="no"
 					rows="10"
-					cols="40" />
+					cols="40"
+					syntax="css"
+					filter="raw" />
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
This PR changes the form field type of the `customCssCode` field from `textarea` to `editor`.
The bigger form field and the syntax highlighting of codemirror improves the readability of the entered code.